### PR TITLE
fix: genre, price, coverImageUrl 파싱 오류 해결

### DIFF
--- a/src/main/java/org/be/book/dto/AddBookRequest.java
+++ b/src/main/java/org/be/book/dto/AddBookRequest.java
@@ -8,8 +8,9 @@ public class AddBookRequest {
     private String author;
     private String genre;
     private Double price;
-    private String bookDescription;
     private String publisher;
     private String publishedDate;
-    private String coverImage;
+    private String leftCoverImageUrl;
+    private String frontCoverImageUrl;
+    private String backCoverImageUrl;
 }

--- a/src/main/java/org/be/book/model/Book.java
+++ b/src/main/java/org/be/book/model/Book.java
@@ -23,9 +23,6 @@ public class Book {
     @Column(length = 50)
     private String genre;
 
-    @Column(length = 2000)
-    private String bookDescription;
-
     @NotNull
     @Column(nullable = false)
     private Double price;
@@ -37,19 +34,24 @@ public class Book {
     private String publishDate;
 
     @Column(length = 500)
-    private String coverImageUrl;
+    private String leftCoverImageUrl;
+
+    @Column(length = 500)
+    private String frontCoverImageUrl;
+
+    @Column(length = 500)
+    private String backCoverImageUrl;
 
     public Book() {}
 
-    public Book(String title, String author, String bookDescription, double price,
-                String publisher, String publishDate, String coverImageUrl) {
+    public Book(String title, String author,  double price,
+                String publisher, String publishDate, String frontCoverImageUrl) {
         this.title = title;
         this.author = author;
-        this.bookDescription = bookDescription;
         this.price = price;
         this.publisher = publisher;
         this.publishDate = publishDate;
-        this.coverImageUrl = coverImageUrl;
+        this.frontCoverImageUrl = frontCoverImageUrl;
     }
 
     public Long getId() { return id; }
@@ -64,9 +66,6 @@ public class Book {
     public String getGenre() { return genre; }
     public void setGenre(String genre) { this.genre = genre; }
 
-    public String getBookDescription() { return bookDescription; }
-    public void setBookDescription(String bookDescription) { this.bookDescription = bookDescription; }
-
     public Double getPrice() { return price; }
     public void setPrice(Double price) { this.price = price; }
 
@@ -76,6 +75,12 @@ public class Book {
     public String getPublishDate() { return publishDate; }
     public void setPublishDate(String publishDate) { this.publishDate = publishDate; }
 
-    public String getCoverImageUrl() { return coverImageUrl; }
-    public void setCoverImageUrl(String coverImageUrl) { this.coverImageUrl = coverImageUrl; }
+    public String getLeftCoverImageUrl() { return leftCoverImageUrl; }
+    public void setLeftCoverImageUrl(String leftCoverImageUrl) { this.leftCoverImageUrl = leftCoverImageUrl; }
+
+    public String getFrontCoverImageUrl() { return frontCoverImageUrl; }
+    public void setFrontCoverImageUrl(String frontCoverImageUrl) { this.frontCoverImageUrl = frontCoverImageUrl; }
+
+    public String getBackCoverImageUrl() { return backCoverImageUrl; }
+    public void setBackCoverImageUrl(String backCoverImageUrl) { this.backCoverImageUrl = backCoverImageUrl; }
 }

--- a/src/main/java/org/be/book/service/BookCrawlingService.java
+++ b/src/main/java/org/be/book/service/BookCrawlingService.java
@@ -11,8 +11,11 @@ import org.jsoup.select.Elements;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -22,10 +25,11 @@ import java.util.regex.Pattern;
 @Service
 @RequiredArgsConstructor
 public class BookCrawlingService {
+
     private final BookRepository bookRepository;
 
     public void crawlBooks() throws Exception {
-        System.setProperty("webdriver.chrome.driver", "/opt/homebrew/bin/chromedriver");
+        System.setProperty("webdriver.chrome.driver", "/usr/bin/chromedriver");
 
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless=new");
@@ -37,81 +41,154 @@ public class BookCrawlingService {
 
         try {
             driver.get(url);
-            Thread.sleep(5000);  // 페이지 로딩 대기
+            Thread.sleep(5000);
 
             String html = driver.getPageSource();
             Document doc = Jsoup.parse(html);
+
+            // 베스트셀러 목록 (예: .ss_book_list:nth-child(2n+1))
             Elements booksList = doc.select(".ss_book_list:nth-child(2n+1)");
+            log.info("🔍 크롤링된 책 개수: {}", booksList.size());
 
             List<Book> books = new ArrayList<>();
-            log.info("🔍 크롤링된 책 개수: {}", booksList.size());
 
             for (Element bookElement : booksList) {
                 Elements liElements = bookElement.select("li");
                 if (liElements.size() < 4) continue;
 
-                // 제목 크롤링
+                // (1) 리스트 페이지에서 제목 추출
                 Element titleElement = liElements.get(1).selectFirst(".bo3");
                 if (titleElement == null) {
-                    log.warn("제목을 찾지 못했습니다. 해당 li 요소: {}", liElements.get(1).html());
-                    continue; // 또는 기본값을 할당하는 방식도 고려할 수 있습니다.
+                    log.warn("제목을 찾지 못했습니다. li 요소: {}", liElements.get(1).html());
+                    continue;
                 }
                 String title = titleElement.text().trim();
 
-                // 책 설명 (내용)
-                String bookDescription = liElements.get(1).selectFirst(".ss_f_g2") != null ?
-                        liElements.get(1).selectFirst(".ss_f_g2").text() : "설명 없음";
-
-                // 작가, 출판사, 발행일
+                // (2) 리스트 페이지에서 작가, 출판사, 발행일 추출
                 String[] bookInfo = liElements.get(2).text().split("\\|");
                 String author = bookInfo[0].trim();
-                String publisher = bookInfo.length > 1 ? bookInfo[1].trim() : "출판사 없음";
-                String rawPublishDate = bookInfo.length > 2 ? bookInfo[2].trim() : "발행일 없음";
+                String publisher = (bookInfo.length > 1) ? bookInfo[1].trim() : "출판사 없음";
+                String rawPublishDate = (bookInfo.length > 2) ? bookInfo[2].trim() : "발행일 없음";
                 String publishDate = rawPublishDate;
-                // "YYYY년 MM월 DD일" 형식을 "YYYY-MM-DD"로 변환
-                Pattern pattern = Pattern.compile("(\\d+)년\\s*(\\d+)월\\s*(\\d+)일");
-                Matcher matcher = pattern.matcher(rawPublishDate);
+                Pattern datePattern = Pattern.compile("(\\d+)년\\s*(\\d+)월\\s*(\\d+)일");
+                Matcher matcher = datePattern.matcher(rawPublishDate);
                 if (matcher.find()) {
                     publishDate = matcher.group(1) + "-" + matcher.group(2) + "-" + matcher.group(3);
                 }
 
-                // 가격 정보 추출 (네 번째 li 요소)
-                String[] priceInfo = liElements.get(3).text().split("→");
-                String originalPriceStr = priceInfo[0].replaceAll("[^0-9]", "").trim();
-                String discountedPriceStr = priceInfo.length > 1 ? priceInfo[1].replaceAll("[^0-9]", "").trim() : originalPriceStr;
-                Double price = 0.0;
-                if (!discountedPriceStr.isEmpty()) {
-                    price = Double.parseDouble(discountedPriceStr);
+                // (3) 리스트 페이지에서 가격 추출
+                Element priceEl = liElements.get(3).selectFirst("span.ss_p2");
+                String priceText = (priceEl != null) ? priceEl.text() : "";
+                String numericPrice = priceText.replaceAll("[^0-9]", "");
+                Double price = numericPrice.isEmpty() ? 0.0 : Double.parseDouble(numericPrice);
+
+                // (4) 리스트 페이지에서 장르 추출
+                Element genreEl = bookElement.selectFirst("span.tit_category");
+                String rawGenre = (genreEl != null) ? genreEl.text() : "";
+                String genre = rawGenre.replace("[", "").replace("]", "").trim();
+                if (genre.isEmpty()) {
+                    genre = "장르 없음";
                 }
 
-                // 커버 이미지 URL 크롤링
-                Element coverImgEl = liElements.get(0).selectFirst("img");
-                String coverImageUrl = coverImgEl != null ? coverImgEl.attr("src") : "이미지 없음";
+                // (5) 리스트 페이지에서 상세 페이지 링크 추출 (bo3 안의 <a> 태그)
+                Element detailLinkEl = titleElement.selectFirst("a");
+                if (detailLinkEl == null) {
+                    log.warn("상세 링크를 찾지 못했습니다. 제목: {}", title);
+                    continue;
+                }
+                String detailUrl = detailLinkEl.absUrl("href");
+
+                // (6) 상세 페이지에서 커버 이미지(앞, 뒤, 왼쪽) 추출
+                String frontCoverImageUrlDetail = "이미지 없음";
+                String backCoverImageUrlDetail = "이미지 없음";
+                String leftCoverImageUrlDetail = "이미지 없음";
+
+                WebDriver detailDriver = new ChromeDriver(options);
+                try {
+                    detailDriver.get(detailUrl);
+                    WebDriverWait wait = new WebDriverWait(detailDriver, Duration.ofSeconds(10));
+
+
+                    //(이건 주제 분륜데,,,)
+//                    try {
+//                        WebElement descElement = wait.until(ExpectedConditions.visibilityOfElementLocated(
+//                                By.cssSelector("div#Ere_prod_allwrap > div.Ere_prod_middlewrap > div.Ere_prod_mconts_box > div.Ere_prod_mconts_R")
+//                        ));
+//                        bookDescription = descElement.getText().trim();
+//                    } catch (TimeoutException e) {
+//                        log.warn("책 소개 로딩 실패");
+//                    }
+//                    log.info("책 소개: {}", bookDescription);
+
+
+                    // 앞 커버 이미지 추출
+                    try {
+                        WebElement frontCoverEl = wait.until(ExpectedConditions.visibilityOfElementLocated(
+                                By.id("CoverMainImage")
+                        ));
+                        frontCoverImageUrlDetail = frontCoverEl.getAttribute("src");
+                    } catch (TimeoutException e) {
+                        log.warn("앞 커버 이미지를 찾지 못했습니다.");
+                    }
+
+                    // 뒤 커버 이미지 추출
+                    try {
+                        WebElement backCoverEl = wait.until(ExpectedConditions.visibilityOfElementLocated(
+                                By.cssSelector("div.c_back img")
+                        ));
+                        backCoverImageUrlDetail = backCoverEl.getAttribute("src");
+                    } catch (TimeoutException e) {
+                        log.warn("뒤 커버 이미지를 찾지 못했습니다.");
+                    }
+
+                    // 왼쪽 커버 이미지 추출
+                    try {
+                        WebElement leftCoverEl = wait.until(ExpectedConditions.visibilityOfElementLocated(
+                                By.cssSelector("div.c_left img")
+                        ));
+                        leftCoverImageUrlDetail = leftCoverEl.getAttribute("src");
+                    } catch (TimeoutException e) {
+                        log.warn("왼쪽 커버 이미지를 찾지 못했습니다.");
+                    }
+                } finally {
+                    detailDriver.quit();
+                }
 
                 log.info("📚 제목: {}", title);
                 log.info("✍️ 작가: {}", author);
                 log.info("🏢 출판사: {}", publisher);
                 log.info("🗓️ 발행일: {}", publishDate);
                 log.info("💰 가격: {}원", price);
-                log.info("🖼️ 커버 이미지: {}", coverImageUrl);
-                log.info("🏷️ 내용: {}", bookDescription);
+                log.info("📖 장르: {}", genre);
+                log.info("🔗 상세 페이지 링크: {}", detailUrl);
+                log.info("🖼️ 상세페이지 앞 커버 이미지: {}", frontCoverImageUrlDetail);
+                log.info("🖼️ 상세페이지 뒤 커버 이미지: {}", backCoverImageUrlDetail);
+                log.info("🖼️ 상세페이지 왼쪽 커버 이미지: {}", leftCoverImageUrlDetail);
                 log.info("----------------------------------");
 
-                // 가격은 필요하지 않으므로 기본값 0.0 사용
-                Book book = new Book(title, author, bookDescription, 0.0, publisher, publishDate, coverImageUrl);
-                // 장르 정보 설정 (예시로 "소설"로 고정)
-                book.setGenre("소설");
+                Book book = new Book(
+                        title,
+                        author,
+                        price,
+                        publisher,
+                        publishDate,
+                        frontCoverImageUrlDetail // 대표 이미지로 앞 커버 사용
+                );
+                book.setFrontCoverImageUrl(frontCoverImageUrlDetail);
+                book.setBackCoverImageUrl(backCoverImageUrlDetail);
+                book.setLeftCoverImageUrl(leftCoverImageUrlDetail);
+                book.setGenre(genre);
 
                 try {
                     bookRepository.save(book);
                 } catch (Exception e) {
                     log.error("❌ 책 저장 실패: {}", e.getMessage());
                 }
-
                 books.add(book);
             }
 
             log.info("✅ 총 {}권의 책을 저장했습니다.", books.size());
+
         } finally {
             driver.quit();
         }

--- a/src/main/java/org/be/book/service/BookService.java
+++ b/src/main/java/org/be/book/service/BookService.java
@@ -37,11 +37,11 @@ public class BookService {
         book.setTitle(request.getTitle());
         book.setAuthor(request.getAuthor());
         book.setGenre(request.getGenre());
-        book.setBookDescription(request.getBookDescription());
         book.setPrice(request.getPrice());
         book.setPublisher(request.getPublisher());
         book.setPublishDate(request.getPublishedDate());
-        book.setCoverImageUrl(request.getCoverImage());
+        book.setLeftCoverImageUrl(request.getLeftCoverImageUrl());
+        book.setFrontCoverImageUrl(request.getFrontCoverImageUrl());
 
         return bookRepository.save(book);
     }


### PR DESCRIPTION
이전의 genre, bookDescription, price, coverImageUrl은 제대로 파싱 안되는 오류 해결
bookDescription은 페이지마다 구조가 달라 제대로 파싱 되지 않아, 일단 해당 부분은 없앴음

- genre는 국내/국외로만 구분되고 있음
- price는 제대로 파싱되고 있음(근데 정가 아니고 할인가가 파싱됨)
- coverImageUrl은 일단은 db에 string으로 저장중인데 S3 고려 중. 나중에 3D 책 이미지 위해서 앞, 뒤, 옆 표지 url 받아옴. 가끔 앞만 있는 책들도 존재함

