### PR TITLE
feat : group 기능 api 8개 구현

### DIFF
--- a/src/main/java/org/be/community/entity/CommunityPost.java
+++ b/src/main/java/org/be/community/entity/CommunityPost.java
@@ -3,6 +3,7 @@ package org.be.community.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.be.auth.model.User;
+import org.be.group.entity.UserGroup;
 
 import java.time.LocalDateTime;
 
@@ -30,6 +31,10 @@ public class CommunityPost {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private UserGroup group;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/org/be/group/controller/GroupController.java
+++ b/src/main/java/org/be/group/controller/GroupController.java
@@ -1,0 +1,34 @@
+package org.be.group.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.be.group.dto.GroupCreateRequestDto;
+import org.be.group.dto.GroupResponseDto;
+import org.be.group.service.GroupMemberService;
+import org.be.group.service.GroupService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
+
+    // 그룹 생성
+    @PostMapping
+    public ResponseEntity<GroupResponseDto> createGroup(@RequestBody GroupCreateRequestDto requestDto,
+                                                        Authentication authentication) {
+        return ResponseEntity.ok(groupService.createGroup(requestDto, authentication));
+    }
+
+    // 전체 그룹 조회
+    @GetMapping
+    public ResponseEntity<List<GroupResponseDto>> getAllGroups() {
+        return ResponseEntity.ok(groupService.getAllGroups());
+    }
+}

--- a/src/main/java/org/be/group/controller/GroupMemberController.java
+++ b/src/main/java/org/be/group/controller/GroupMemberController.java
@@ -1,0 +1,62 @@
+package org.be.group.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.be.group.dto.GroupMemberResponseDto;
+import org.be.group.dto.GroupResponseDto;
+import org.be.group.service.GroupMemberService;
+import org.be.auth.service.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups/{groupId}/members")
+public class GroupMemberController {
+
+    private final GroupMemberService groupMemberService;
+
+    @PostMapping("/join")
+    public ResponseEntity<Void> joinGroup(@PathVariable Long groupId,
+                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        groupMemberService.joinGroup(groupId, userDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/leave")
+    public ResponseEntity<Void> leaveGroup(@PathVariable Long groupId,
+                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        groupMemberService.leaveGroup(groupId, userDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GroupMemberResponseDto>> getGroupMembers(@PathVariable Long groupId) {
+        List<GroupMemberResponseDto> members = groupMemberService.getGroupMembers(groupId);
+        return ResponseEntity.ok(members);
+    }
+
+    @DeleteMapping("/kick/{userId}")
+    public ResponseEntity<Void> kickMember(@PathVariable Long groupId,
+                                           @PathVariable Long userId,
+                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        groupMemberService.kickMember(groupId, userDetails.getUser(), userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/transfer/{userId}")
+    public ResponseEntity<Void> transferLeadership(@PathVariable Long groupId,
+                                                   @PathVariable Long userId,
+                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
+        groupMemberService.transferLeadership(groupId, userDetails.getUser(), userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<GroupResponseDto>> getMyGroups(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<GroupResponseDto> myGroups = groupMemberService.getMyGroups(userDetails.getUser());
+        return ResponseEntity.ok(myGroups);
+    }
+}

--- a/src/main/java/org/be/group/controller/MyGroupController.java
+++ b/src/main/java/org/be/group/controller/MyGroupController.java
@@ -1,0 +1,26 @@
+package org.be.group.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.be.auth.service.CustomUserDetails;
+import org.be.group.dto.GroupResponseDto;
+import org.be.group.service.GroupMemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups/my")
+class MyGroupController {
+
+    private final GroupMemberService groupMemberService;
+
+    @GetMapping
+    public ResponseEntity<List<GroupResponseDto>> getMyGroups(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(groupMemberService.getMyGroups(userDetails.getUser()));
+    }
+}

--- a/src/main/java/org/be/group/dto/GroupCreateRequestDto.java
+++ b/src/main/java/org/be/group/dto/GroupCreateRequestDto.java
@@ -1,0 +1,12 @@
+package org.be.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupCreateRequestDto {
+    @NotBlank(message = "그룹 이름은 필수입니다.")
+    private String name;
+}

--- a/src/main/java/org/be/group/dto/GroupJoinRequestDto.java
+++ b/src/main/java/org/be/group/dto/GroupJoinRequestDto.java
@@ -1,0 +1,13 @@
+package org.be.group.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupJoinRequestDto {
+
+    @NotNull(message = "그룹 ID는 필수입니다.")
+    private Long groupId;
+}

--- a/src/main/java/org/be/group/dto/GroupMemberResponseDto.java
+++ b/src/main/java/org/be/group/dto/GroupMemberResponseDto.java
@@ -1,0 +1,25 @@
+package org.be.group.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.be.group.entity.GroupMember;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupMemberResponseDto {
+    private Long userId;
+    private String username;
+    private String role;  // LEADER or MEMBER
+
+    public static GroupMemberResponseDto fromEntity(GroupMember member) {
+        return GroupMemberResponseDto.builder()
+                .userId(member.getUser().getId())
+                .username(member.getUser().getUsername())
+                .role(member.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/org/be/group/dto/GroupResponseDto.java
+++ b/src/main/java/org/be/group/dto/GroupResponseDto.java
@@ -1,0 +1,18 @@
+package org.be.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupResponseDto {
+    private Long id;
+    private String name;
+
+    public static GroupResponseDto fromEntity(org.be.group.entity.UserGroup userGroup) {
+        return GroupResponseDto.builder()
+                .id(userGroup.getId())
+                .name(userGroup.getName())
+                .build();
+    }
+}

--- a/src/main/java/org/be/group/entity/GroupMember.java
+++ b/src/main/java/org/be/group/entity/GroupMember.java
@@ -1,0 +1,34 @@
+package org.be.group.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.be.auth.model.User;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private UserGroup group;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    public enum Role {
+        LEADER, MEMBER
+    }
+}

--- a/src/main/java/org/be/group/entity/UserGroup.java
+++ b/src/main/java/org/be/group/entity/UserGroup.java
@@ -1,0 +1,26 @@
+package org.be.group.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user_group")
+public class UserGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GroupMember> members = new ArrayList<>();
+}

--- a/src/main/java/org/be/group/repository/GroupMemberRepository.java
+++ b/src/main/java/org/be/group/repository/GroupMemberRepository.java
@@ -1,0 +1,18 @@
+package org.be.group.repository;
+
+import org.be.group.entity.UserGroup;
+import org.be.group.entity.GroupMember;
+import org.be.auth.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    Optional<GroupMember> findByGroupAndUser(UserGroup userGroup, User user);
+
+    List<GroupMember> findByGroup(UserGroup userGroup);
+
+    List<GroupMember> findByUser(User user); // 사용자가 참여한 그룹 리스트 조회
+}

--- a/src/main/java/org/be/group/repository/GroupRepository.java
+++ b/src/main/java/org/be/group/repository/GroupRepository.java
@@ -1,0 +1,13 @@
+package org.be.group.repository;
+
+import org.be.group.entity.UserGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupRepository extends JpaRepository<UserGroup, Long> {
+
+    Optional<UserGroup> findByName(String name);
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/org/be/group/service/GroupMemberService.java
+++ b/src/main/java/org/be/group/service/GroupMemberService.java
@@ -1,0 +1,110 @@
+package org.be.group.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.be.group.dto.GroupMemberResponseDto;
+import org.be.group.dto.GroupResponseDto;
+import org.be.group.entity.UserGroup;
+import org.be.group.entity.GroupMember;
+import org.be.group.repository.GroupMemberRepository;
+import org.be.auth.model.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupMemberService {
+
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupService groupService;
+
+    public void joinGroup(Long groupId, User user) {
+        UserGroup userGroup = groupService.findGroupById(groupId);
+
+        if (groupMemberRepository.findByGroupAndUser(userGroup, user).isPresent()) {
+            throw new IllegalStateException("이미 그룹에 가입되어 있습니다.");
+        }
+
+        GroupMember member = GroupMember.builder()
+                .user(user)
+                .group(userGroup)
+                .role(GroupMember.Role.MEMBER)
+                .build();
+        groupMemberRepository.save(member);
+    }
+
+    public void leaveGroup(Long groupId, User user) {
+        UserGroup userGroup = groupService.findGroupById(groupId);
+        GroupMember member = groupMemberRepository.findByGroupAndUser(userGroup, user)
+                .orElseThrow(() -> new IllegalStateException("그룹에 가입되어 있지 않습니다."));
+
+        if (member.getRole() == GroupMember.Role.LEADER) {
+            throw new IllegalStateException("방장은 권한을 위임한 후 탈퇴할 수 있습니다.");
+        }
+
+        groupMemberRepository.delete(member);
+    }
+
+    public List<GroupMemberResponseDto> getGroupMembers(Long groupId) {
+        UserGroup userGroup = groupService.findGroupById(groupId);
+
+        return groupMemberRepository.findByGroup(userGroup).stream()
+                .map(GroupMemberResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public void kickMember(Long groupId, User leaderUser, Long targetUserId) {
+        UserGroup userGroup = groupService.findGroupById(groupId);
+
+        GroupMember leader = groupMemberRepository.findByGroupAndUser(userGroup, leaderUser)
+                .orElseThrow(() -> new IllegalStateException("그룹 소속이 아닙니다."));
+
+        if (leader.getRole() != GroupMember.Role.LEADER) {
+            throw new IllegalStateException("방장만 다른 멤버를 강퇴할 수 있습니다.");
+        }
+
+        GroupMember target = groupMemberRepository.findByGroup(userGroup).stream()
+                .filter(m -> m.getUser().getId().equals(targetUserId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("대상 사용자가 그룹에 존재하지 않습니다."));
+
+        if (target.getRole() == GroupMember.Role.LEADER) {
+            throw new IllegalStateException("방장은 스스로를 강퇴할 수 없습니다.");
+        }
+
+        groupMemberRepository.delete(target);
+    }
+
+    public void transferLeadership(Long groupId, User currentLeaderUser, Long newLeaderUserId) {
+        UserGroup userGroup = groupService.findGroupById(groupId);
+
+        GroupMember currentLeader = groupMemberRepository.findByGroupAndUser(userGroup, currentLeaderUser)
+                .orElseThrow(() -> new IllegalStateException("그룹 소속이 아닙니다."));
+
+        if (currentLeader.getRole() != GroupMember.Role.LEADER) {
+            throw new IllegalStateException("현재 사용자는 방장이 아닙니다.");
+        }
+
+        GroupMember newLeader = groupMemberRepository.findByGroup(userGroup).stream()
+                .filter(m -> m.getUser().getId().equals(newLeaderUserId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("새 방장 대상 사용자가 그룹에 존재하지 않습니다."));
+
+        // 권한 교체
+        currentLeader.setRole(GroupMember.Role.MEMBER);
+        newLeader.setRole(GroupMember.Role.LEADER);
+
+        groupMemberRepository.save(currentLeader);
+        groupMemberRepository.save(newLeader);
+    }
+
+    public List<GroupResponseDto> getMyGroups(User user) {
+        return groupMemberRepository.findByUser(user)
+                .stream()
+                .map(groupMember -> GroupResponseDto.fromEntity(groupMember.getGroup()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/be/group/service/GroupService.java
+++ b/src/main/java/org/be/group/service/GroupService.java
@@ -1,0 +1,76 @@
+package org.be.group.service;
+
+import lombok.RequiredArgsConstructor;
+import org.be.group.dto.GroupCreateRequestDto;
+import org.be.group.dto.GroupResponseDto;
+import org.be.group.entity.UserGroup;
+import org.be.group.entity.GroupMember;
+import org.be.group.repository.GroupMemberRepository;
+import org.be.group.repository.GroupRepository;
+import org.be.auth.model.User;
+import org.be.auth.service.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupResponseDto createGroup(GroupCreateRequestDto requestDto, Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User user = userDetails.getUser();
+
+        if (groupRepository.existsByName(requestDto.getName())) {
+            throw new IllegalArgumentException("이미 존재하는 그룹 이름입니다.");
+        }
+
+        UserGroup group = UserGroup.builder()
+                .name(requestDto.getName())
+                .build();
+        groupRepository.save(group);
+
+        // 그룹 생성자는 자동으로 방장 등록
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.Role.LEADER)
+                .build();
+        groupMemberRepository.save(groupMember);
+
+        return GroupResponseDto.fromEntity(group);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupResponseDto> getAllGroups() {
+        return groupRepository.findAll()
+                .stream()
+                .map(GroupResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<GroupResponseDto> getMyGroups(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User user = userDetails.getUser();
+
+        return groupMemberRepository.findByUser(user)
+                .stream()
+                .map(GroupMember::getGroup)
+                .map(GroupResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public UserGroup findGroupById(Long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("그룹을 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
- 그룹 생성 (생성자가 리더가 됨)
- 그룹 참가
- 그룹 탈퇴
- 방장 권한 위임
- 유저 강퇴 (리더만 가능)
- 전체 그룹 조회
- 내가 속한 그룹 조회
- 특정 그룹 멤버 조회

이렇게 8개 api 구현했습니다. 전체 그룹 조회의 경우, 토큰 인증이 필요 없어서 그 부분은 리팩토링 할 예정입니다,,,,