### PR TITLE
feat : 소속한 group 내에서만 글 작성 가능하도록, 방장 게시물 삭제 권한 부여

### DIFF
--- a/src/main/java/org/be/auth/config/SecurityConfig.java
+++ b/src/main/java/org/be/auth/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/book/**").permitAll()
                         .requestMatchers("/images/**").permitAll()
                         .requestMatchers("/api/groups").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/community/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/community/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/swagger-ui.html").permitAll()

--- a/src/main/java/org/be/community/service/CommunityPostService.java
+++ b/src/main/java/org/be/community/service/CommunityPostService.java
@@ -2,13 +2,15 @@ package org.be.community.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.be.auth.service.CustomUserDetails;
+import org.be.auth.model.User;
 import org.be.community.dto.CommunityPostRequestDto;
 import org.be.community.dto.CommunityPostResponseDto;
 import org.be.community.entity.CommunityPost;
 import org.be.community.repository.CommunityPostRepository;
+import org.be.group.entity.UserGroup;
+import org.be.group.service.GroupMemberService;
+import org.be.group.service.GroupService;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,8 @@ import java.util.stream.Collectors;
 public class CommunityPostService {
 
     private final CommunityPostRepository postRepository;
+    private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
 
     public List<CommunityPostResponseDto> getAllPosts() {
         return postRepository.findAllWithUser()
@@ -28,32 +32,35 @@ public class CommunityPostService {
                 .collect(Collectors.toList());
     }
 
-    public CommunityPostResponseDto getPostById(Long id) {
+    public CommunityPostResponseDto getPost(Long id) {
         CommunityPost post = postRepository.findByIdWithUser(id)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
         return CommunityPostResponseDto.fromEntity(post);
     }
 
-    public CommunityPostResponseDto createPost(CommunityPostRequestDto dto, Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    public CommunityPostResponseDto createPost(Long groupId, CommunityPostRequestDto dto, User user) {
+        UserGroup group = groupService.findGroupById(groupId);
+
+        if (!groupMemberService.isMember(groupId, user)) {
+            throw new IllegalStateException("그룹에 가입된 사용자만 글을 작성할 수 있습니다.");
+        }
 
         CommunityPost post = CommunityPost.builder()
                 .title(dto.getTitle())
                 .content(dto.getContent())
-                .user(userDetails.getUser())
+                .user(user)
+                .group(group)
                 .build();
 
         return CommunityPostResponseDto.fromEntity(postRepository.save(post));
     }
 
     @Transactional
-    public CommunityPostResponseDto updatePost(Long id, CommunityPostRequestDto dto, Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-
+    public CommunityPostResponseDto updatePost(Long id, CommunityPostRequestDto dto, User user) {
         CommunityPost post = postRepository.findByIdWithUser(id)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
 
-        if (!post.getUser().getUserId().equals(userDetails.getUsername())) {
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new AccessDeniedException("게시글 작성자만 수정할 수 있습니다.");
         }
 
@@ -63,17 +70,17 @@ public class CommunityPostService {
         return CommunityPostResponseDto.fromEntity(postRepository.save(post));
     }
 
-    public void deletePost(Long id, Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    public void deletePost(Long postId, User user) {
+        CommunityPost post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
-        CommunityPost post = postRepository.findByIdWithUser(id)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+        boolean isAuthor = post.getUser().getId().equals(user.getId());
+        boolean isLeader = groupMemberService.isLeader(post.getGroup().getId(), user);
 
-        if (!post.getUser().getUserId().equals(userDetails.getUsername())) {
-            throw new AccessDeniedException("게시글 작성자만 삭제할 수 있습니다.");
+        if (!isAuthor && !isLeader) {
+            throw new IllegalStateException("게시글 작성자나 그룹의 방장만 삭제할 수 있습니다.");
         }
 
         postRepository.delete(post);
     }
-
 }

--- a/src/main/java/org/be/group/service/GroupMemberService.java
+++ b/src/main/java/org/be/group/service/GroupMemberService.java
@@ -107,4 +107,16 @@ public class GroupMemberService {
                 .map(groupMember -> GroupResponseDto.fromEntity(groupMember.getGroup()))
                 .collect(Collectors.toList());
     }
+
+    public boolean isMember(Long groupId, User user) {
+        UserGroup group = groupService.findGroupById(groupId);
+        return groupMemberRepository.findByGroupAndUser(group, user).isPresent();
+    }
+
+    public boolean isLeader(Long groupId, User user) {
+        UserGroup group = groupService.findGroupById(groupId);
+        return groupMemberRepository.findByGroupAndUser(group, user)
+                .filter(m -> m.getRole() == GroupMember.Role.LEADER)
+                .isPresent();
+    }
 }


### PR DESCRIPTION
- 그룹의 방장은 적절하지 않다고 판단하는 게시물을 삭제할 수 있음
- 그룹에 참여하지 않은 사용자는 그룹 내에 게시글을 작성할 수 없음
- 사용자가 그룹을 나가도 이전에 작성한 게시글은 삭제되지 않음
- 게시물 단건 조회, 전체 조회는 토큰 필요 없이 조회 가능