### PR TITLE
Fix: 첫 번째  추천 요청 시 추천 결과가 전달되지 않던 문제 해결

### DIFF
--- a/src/main/java/org/be/recommend/controller/RecommendController.java
+++ b/src/main/java/org/be/recommend/controller/RecommendController.java
@@ -19,7 +19,6 @@ public class RecommendController {
 
     private static final Logger log = LoggerFactory.getLogger(RecommendController.class);
 
-    // 클라이언트가 POST로 추천 요청 보내는 엔드포인트
     @PostMapping
     @Transactional
     public ResponseEntity<?> recommendBooks(@AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -27,21 +26,37 @@ public class RecommendController {
 
         RecommendResponse cachedRecommendations = recommendService.checkCache(userId);
 
-        // null이거나 캐시는 존재하나 값이 비어있지 않으면
-        if (cachedRecommendations != null &&
-                cachedRecommendations.getRecommendedBooks() != null &&
-                !cachedRecommendations.getRecommendedBooks().isEmpty()) {            // Redis에 추천 결과가 있으면 바로 반환
-
+        // Redis에 추천 결과가 있으면 (null이거나 캐시는 존재하나 값이 비어있지 않으면)
+        if (cachedRecommendations != null && !cachedRecommendations.getRecommendedBooks().isEmpty()) {
             log.info("[CACHE HIT] 추천 결과 반환 - userId={}", userId);
             return ResponseEntity.ok(cachedRecommendations);
         }
 
         // Redis에 추천 결과가 없으면 Kafka로 추천 요청을 보낸다
-        log.info("추천 결과가 비어 있음. 추천 요청 중 - userId={}", userId);
+        log.info("추천 결과 없음. Kafka로 추천 요청 전송 - userId={}", userId);
         recommendService.recommendBooks(userDetails.getUser());
 
-        // 추천 생성 중이니까 "추천 생성 요청 완료" 메시지를 응답
-        // 추천 결과가 아직 생성되지 않았음을 알려줌
+        // 추천 결과가 Redis에 저장될 때까지 일정 시간 동안 반복적으로 확인하는 결과 폴링
+        // 최대 5초 동안 100ms 간격으로 Redis 확인
+        int maxAttempts = 50;
+        int delayMillis = 100;
+        for (int i = 0; i < maxAttempts; i++) {
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            RecommendResponse result = recommendService.checkCache(userId);
+            if (result != null && result.getRecommendedBooks() != null && !result.getRecommendedBooks().isEmpty()) {
+                log.info("[ASYNC POLL SUCCESS] 추천 결과 확보 - userId={}", userId);
+                return ResponseEntity.ok(result);
+            }
+        }
+
+        // 추천 결과가 5초 안에 생성되지 않았거나, 추천 결과 생성 실패
+        log.warn("[ASYNC POLL TIMEOUT] 추천 결과 생성 실패 - userId={}", userId);
         return ResponseEntity.status(202) // 202 Accepted
                 .body("추천 결과를 생성 중입니다. 잠시 후 다시 요청하세요.");
     }

--- a/src/main/java/org/be/recommend/dto/RecommendResponse.java
+++ b/src/main/java/org/be/recommend/dto/RecommendResponse.java
@@ -16,6 +16,8 @@ public class RecommendResponse {
         private String author;
         private String coverImageUrl;
 
+        public RecommendBook() {}
+
         public RecommendBook(Long bookId, String title, String author, String coverImageUrl) {
             this.bookId = bookId;
             this.title = title;


### PR DESCRIPTION
- 추천 로직의 비동기 문제로 인한 첫 번째 추천 요청 시 추천 결과가 전달되지 않고, 다시 요청해야 하던 문제 해결
  - 추천 결과가 Redis에 저장될 때까지 일정 시간 동안 반복적으로 확인하는 결과 폴링
  - 최대 5초 동안 100ms 간격으로 Redis 확인
- Kafka 메시지 역직렬화로 인한 버그 해결