### PR TITLE
feat : 독후감 관련 api 8개 추가

### DIFF
--- a/src/main/java/org/be/auth/config/SecurityConfig.java
+++ b/src/main/java/org/be/auth/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/community/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/groups").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/groups").authenticated()
+                        .requestMatchers("/api/reports/**").authenticated()
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/swagger-ui.html").permitAll()

--- a/src/main/java/org/be/auth/model/User.java
+++ b/src/main/java/org/be/auth/model/User.java
@@ -60,4 +60,17 @@ public class User {
 
     public String getRole() { return role; }
     public void setRole(String role) { this.role = role; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User)) return false;
+        User user = (User) o;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
 }

--- a/src/main/java/org/be/book/controller/ReportController.java
+++ b/src/main/java/org/be/book/controller/ReportController.java
@@ -1,0 +1,102 @@
+package org.be.book.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.be.auth.service.CustomUserDetails;
+import org.be.book.dto.ReportRequest;
+import org.be.book.dto.ReportResponse;
+import org.be.book.model.Book;
+import org.be.book.repository.BookRepository;
+import org.be.book.service.ReportService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    private final ReportService reportService;
+    private final BookRepository bookRepository;
+
+    private void validateAuth(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+    }
+
+    // 1. 독후감 작성
+    @PostMapping
+    public ResponseEntity<ReportResponse> writeReport(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                      @RequestBody ReportRequest request) {
+        validateAuth(userDetails);
+        ReportResponse response = reportService.create(userDetails.getUser(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 2. 내 독후감 전체 조회
+    @GetMapping("/me")
+    public ResponseEntity<List<ReportResponse>> getMyReports(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAuth(userDetails);
+        return ResponseEntity.ok(reportService.getMyReports(userDetails.getUser()));
+    }
+
+    // 3. 내 독후감 단건 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ReportResponse> getReport(@PathVariable Long id,
+                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok(reportService.get(id, userDetails.getUser()));
+    }
+
+    // 4. 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateReport(@PathVariable Long id,
+                                             @RequestBody ReportRequest request,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        reportService.update(id, userDetails.getUser(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 5. 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteReport(@PathVariable Long id,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        reportService.delete(id, userDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    // 6. 특정 책에 대한 공개 독후감 조회
+    @GetMapping("/book/{bookId}")
+    public ResponseEntity<List<ReportResponse>> getReportsByBook(@PathVariable Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 책입니다."));
+        return ResponseEntity.ok(reportService.getPublicReportsByBook(book));
+    }
+
+    // 7. 전체 공개 독후감 목록
+    @GetMapping("/public")
+    public ResponseEntity<List<ReportResponse>> getPublicReports() {
+        return ResponseEntity.ok(reportService.getAllPublicReports());
+    }
+
+    // 8. 공개된 단건 독후감
+    @GetMapping("/public/{id}")
+    public ResponseEntity<ReportResponse> getPublicReport(@PathVariable Long id) {
+        return ResponseEntity.ok(reportService.getPublicReport(id));
+    }
+}

--- a/src/main/java/org/be/book/dto/ReportRequest.java
+++ b/src/main/java/org/be/book/dto/ReportRequest.java
@@ -1,0 +1,13 @@
+package org.be.book.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReportRequest {
+    private Long bookId;
+    private String content;
+    private int rating;
+    private Boolean publicVisible;
+}

--- a/src/main/java/org/be/book/dto/ReportResponse.java
+++ b/src/main/java/org/be/book/dto/ReportResponse.java
@@ -1,0 +1,34 @@
+package org.be.book.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReportResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private int rating;
+    private Boolean publicVisible; // ✅ 수정
+    private String bookTitle;
+    private String authorName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ReportResponse from(org.be.book.model.Report report) {
+        return ReportResponse.builder()
+                .id(report.getId())
+                .title(report.getTitle())
+                .content(report.getContent())
+                .rating(report.getRating())
+                .publicVisible(report.getPublicVisible()) // ✅ getter 명확히
+                .bookTitle(report.getBook().getTitle())
+                .authorName(report.getAuthor().getUsername())
+                .createdAt(report.getCreatedAt())
+                .updatedAt(report.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/be/book/model/Report.java
+++ b/src/main/java/org/be/book/model/Report.java
@@ -1,0 +1,50 @@
+package org.be.book.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.be.auth.model.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private User author;
+
+    @ManyToOne(optional = false)
+    private Book book;
+
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    private int rating;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean publicVisible; // ✅ 필드명 변경 (DB 컬럼명은 그대로)
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/be/book/repository/ReportRepository.java
+++ b/src/main/java/org/be/book/repository/ReportRepository.java
@@ -1,0 +1,15 @@
+package org.be.book.repository;
+
+import org.be.auth.model.User;
+import org.be.book.model.Book;
+import org.be.book.model.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    List<Report> findByAuthor(User user);
+    List<Report> findByBookAndPublicVisibleTrue(Book book);
+    List<Report> findByPublicVisibleTrue();
+}

--- a/src/main/java/org/be/book/service/ReportService.java
+++ b/src/main/java/org/be/book/service/ReportService.java
@@ -1,0 +1,116 @@
+package org.be.book.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.be.auth.model.User;
+import org.be.book.dto.ReportRequest;
+import org.be.book.dto.ReportResponse;
+import org.be.book.model.Book;
+import org.be.book.model.Report;
+import org.be.book.repository.BookRepository;
+import org.be.book.repository.ReportRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final BookRepository bookRepository;
+
+    @Transactional
+    public ReportResponse create(User user, ReportRequest request) {
+        Book book = bookRepository.findById(request.getBookId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 책이 없습니다."));
+
+        Report report = new Report();
+        report.setAuthor(user);
+        report.setBook(book);
+        report.setTitle(book.getTitle());
+        report.setContent(request.getContent());
+        report.setRating(request.getRating());
+        report.setPublicVisible(request.getPublicVisible()); // ✅ 명확하게 값 전달
+
+        log.info("📩 요청 받은 공개 여부: {}", request.getPublicVisible());
+        log.info("🧪 before save - isPublic: {}", report.getPublicVisible());
+
+        reportRepository.save(report);
+
+        log.info("📦 after save - isPublic: {}", report.getPublicVisible());
+
+        return ReportResponse.from(report);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReportResponse> getMyReports(User user) {
+        return reportRepository.findByAuthor(user).stream()
+                .map(ReportResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ReportResponse get(Long id, User user) {
+        Report report = reportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 독후감입니다."));
+        if (!report.getAuthor().equals(user)) {
+            throw new AccessDeniedException("본인의 독후감만 조회할 수 있습니다.");
+        }
+        return ReportResponse.from(report);
+    }
+
+    @Transactional
+    public void update(Long id, User user, ReportRequest request) {
+        Report report = reportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 독후감입니다."));
+        if (!report.getAuthor().equals(user)) {
+            throw new AccessDeniedException("본인의 독후감만 수정할 수 있습니다.");
+        }
+
+        report.setContent(request.getContent());
+        report.setRating(request.getRating());
+        report.setPublicVisible(request.getPublicVisible()); // ✅ 수정도 동일하게
+    }
+
+    @Transactional
+    public void delete(Long id, User user) {
+        Report report = reportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 독후감입니다."));
+        if (!report.getAuthor().equals(user)) {
+            throw new AccessDeniedException("본인의 독후감만 삭제할 수 있습니다.");
+        }
+
+        reportRepository.delete(report);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReportResponse> getPublicReportsByBook(Book book) {
+        return reportRepository.findByBookAndPublicVisibleTrue(book).stream()
+                .map(ReportResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReportResponse> getAllPublicReports() {
+        return reportRepository.findByPublicVisibleTrue().stream()
+                .map(ReportResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ReportResponse getPublicReport(Long id) {
+        Report report = reportRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 독후감입니다."));
+        if (!Boolean.TRUE.equals(report.getPublicVisible())) {
+            throw new AccessDeniedException("비공개 독후감은 조회할 수 없습니다.");
+        }
+        return ReportResponse.from(report);
+    }
+}


### PR DESCRIPTION
- 독후감 작성
- 본인 독후감 전체 조회
- 본인 독후감 단건 조회
- 독후감 수정
- 독후감 삭제
- 특정 책의 공개된 독후감 조회
- 전체 공개 독후감 목록 조회
- 공개된 단건 독후감 조회

이렇게 8개 api 추가됐습니다.